### PR TITLE
Add dependabot configuration for dependency patching

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,5 +36,7 @@ updates:
     open-pull-requests-limit: 3
     reviewers:
       - "caleb-wells"
+    assignees:
+      - "caleb-wells"
     commit-message:
       prefix: "ci"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+updates:
+  # Main Astro application dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "caleb-wells"
+    assignees:
+      - "caleb-wells"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  # CDK infrastructure dependencies
+  - package-ecosystem: "npm"
+    directory: "/infrastructure"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "caleb-wells"
+    assignees:
+      - "caleb-wells"
+    commit-message:
+      prefix: "deps(infra)"
+      include: "scope"
+
+  # GitHub Actions dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 3
+    reviewers:
+      - "caleb-wells"
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
Close #3 

This pull request introduces a new Dependabot configuration file to automate dependency updates for the project. The configuration includes separate update schedules and settings for the main application, infrastructure, and GitHub Actions dependencies.

### Dependabot configuration:

* Added `.github/dependabot.yml` to define automated dependency updates:
  - **Main application dependencies**: Weekly updates for `npm` packages in the root directory, with a limit of 10 open pull requests.
  - **Infrastructure dependencies**: Weekly updates for `npm` packages in the `/infrastructure` directory, with a limit of 5 open pull requests.
  - **GitHub Actions dependencies**: Monthly updates for dependencies in the root directory, with a limit of 3 open pull requests.